### PR TITLE
Fix two bugs, and a little cleanup

### DIFF
--- a/main.go
+++ b/main.go
@@ -204,7 +204,7 @@ func main() {
 func processHorizontalPodAutoscaler(kubeClient *k8s.Client, hpa *autoscalingv1.HorizontalPodAutoscaler, initiator string) (status string, err error) {
 	status = "failed"
 
-	if &hpa != nil && &hpa.Metadata != nil && &hpa.Metadata.Annotations != nil {
+	if hpa != nil && hpa.Metadata != nil && hpa.Metadata.Annotations != nil {
 
 		desiredState := getDesiredHorizontalPodAutoscalerState(hpa)
 

--- a/main.go
+++ b/main.go
@@ -165,7 +165,7 @@ func main() {
 			log.Info().Msg("Listing horizontal pod autoscalers for all namespaces...")
 			hpas, err := client.AutoscalingV1().ListHorizontalPodAutoscalers(context.Background(), k8s.AllNamespaces)
 			if err != nil {
-				log.Error().Err(err).Msg("")
+				log.Error().Err(err).Msg("Could not list the horizontal pod autoscalers in the clusters.")
 			} else {
 				log.Info().Msgf("Cluster has %v horizontal pod autoscalers", len(hpas.Items))
 
@@ -178,7 +178,7 @@ func main() {
 						waitGroup.Done()
 
 						if err != nil {
-							log.Error().Err(err).Msg("")
+							log.Warn().Err(err).Msg("")
 							continue
 						}
 					}

--- a/main.go
+++ b/main.go
@@ -31,13 +31,13 @@ import (
 	autoscalingv1 "github.com/ericchiang/k8s/apis/autoscaling/v1"
 )
 
-const annotationHPAScaler string = "estafette.io/hpa-scaler"
-const annotationHPAScalerPrometheusQuery string = "estafette.io/hpa-scaler-prometheus-query"
-const annotationHPAScalerRequestsPerReplica string = "estafette.io/hpa-scaler-requests-per-replica"
-const annotationHPAScalerDelta string = "estafette.io/hpa-scaler-delta"
+const annotationHPAScaler = "estafette.io/hpa-scaler"
+const annotationHPAScalerPrometheusQuery = "estafette.io/hpa-scaler-prometheus-query"
+const annotationHPAScalerRequestsPerReplica = "estafette.io/hpa-scaler-requests-per-replica"
+const annotationHPAScalerDelta = "estafette.io/hpa-scaler-delta"
 const annotationHPAScalerPrometheusServerURL = "estafette.io/hpa-scaler-prometheus-server-url"
 
-const annotationHPAScalerState string = "estafette.io/hpa-scaler-state"
+const annotationHPAScalerState = "estafette.io/hpa-scaler-state"
 
 // HPAScalerState represents the state of the HorizontalPodAutoscaler with respect to the Estafette k8s hpa scaler
 type HPAScalerState struct {
@@ -134,7 +134,7 @@ func main() {
 	// create kubernetes api client
 	client, err := k8s.NewInClusterClient()
 	if err != nil {
-		log.Fatal().Err(err)
+		log.Fatal().Err(err).Msg("")
 	}
 
 	// start prometheus
@@ -165,21 +165,22 @@ func main() {
 			log.Info().Msg("Listing horizontal pod autoscalers for all namespaces...")
 			hpas, err := client.AutoscalingV1().ListHorizontalPodAutoscalers(context.Background(), k8s.AllNamespaces)
 			if err != nil {
-				log.Error().Err(err)
-			}
-			log.Info().Msgf("Cluster has %v horizontal pod autoscalers", len(hpas.Items))
+				log.Error().Err(err).Msg("")
+			} else {
+				log.Info().Msgf("Cluster has %v horizontal pod autoscalers", len(hpas.Items))
 
-			// loop all hpas
-			if hpas != nil && hpas.Items != nil {
-				for _, hpa := range hpas.Items {
-					waitGroup.Add(1)
-					status, err := processHorizontalPodAutoscaler(client, hpa, "poller")
-					hpaTotals.With(prometheus.Labels{"namespace": *hpa.Metadata.Namespace, "status": status, "initiator": "poller"}).Inc()
-					waitGroup.Done()
+				// loop all hpas
+				if hpas != nil && hpas.Items != nil {
+					for _, hpa := range hpas.Items {
+						waitGroup.Add(1)
+						status, err := processHorizontalPodAutoscaler(client, hpa, "poller")
+						hpaTotals.With(prometheus.Labels{"namespace": *hpa.Metadata.Namespace, "status": status, "initiator": "poller"}).Inc()
+						waitGroup.Done()
 
-					if err != nil {
-						log.Error().Err(err)
-						continue
+						if err != nil {
+							log.Error().Err(err).Msg("")
+							continue
+						}
 					}
 				}
 			}
@@ -200,15 +201,24 @@ func main() {
 	log.Info().Msg("Shutting down...")
 }
 
-func applyJitter(input int) (output int) {
+func processHorizontalPodAutoscaler(kubeClient *k8s.Client, hpa *autoscalingv1.HorizontalPodAutoscaler, initiator string) (status string, err error) {
+	status = "failed"
 
-	deviation := int(0.25 * float64(input))
+	if &hpa != nil && &hpa.Metadata != nil && &hpa.Metadata.Annotations != nil {
 
-	return input - deviation + r.Intn(2*deviation)
+		desiredState := getDesiredHorizontalPodAutoscalerState(hpa)
+
+		status, err = makeHorizontalPodAutoscalerChanges(kubeClient, hpa, initiator, desiredState)
+
+		return
+	}
+
+	status = "skipped"
+
+	return status, nil
 }
 
 func getDesiredHorizontalPodAutoscalerState(hpa *autoscalingv1.HorizontalPodAutoscaler) (state HPAScalerState) {
-
 	var ok bool
 
 	// get annotations or set default value
@@ -247,17 +257,16 @@ func getDesiredHorizontalPodAutoscalerState(hpa *autoscalingv1.HorizontalPodAuto
 }
 
 func makeHorizontalPodAutoscalerChanges(kubeClient *k8s.Client, hpa *autoscalingv1.HorizontalPodAutoscaler, initiator string, desiredState HPAScalerState) (status string, err error) {
-
-	minimumReplicasLowerBoundString := os.Getenv("MINIMUM_REPLICAS_LOWER_BOUND")
-	minimumReplicasLowerBound := int32(3)
-	if i, err := strconv.ParseInt(minimumReplicasLowerBoundString, 0, 32); err != nil {
-		minimumReplicasLowerBound = int32(i)
-	}
-
 	status = "failed"
 
 	// check if hpa-scaler is enabled for this hpa and query is not empty and requests per replica larger than zero
 	if desiredState.Enabled == "true" && len(desiredState.PrometheusQuery) > 0 && desiredState.RequestsPerReplica > 0 {
+		minimumReplicasLowerBoundString := os.Getenv("MINIMUM_REPLICAS_LOWER_BOUND")
+		minimumReplicasLowerBound := int32(3)
+		if i, err := strconv.ParseInt(minimumReplicasLowerBoundString, 0, 32); err != nil {
+			minimumReplicasLowerBound = int32(i)
+		}
+
 		var ok bool
 		prometheusServerURL, ok := hpa.Metadata.Annotations[annotationHPAScalerPrometheusServerURL]
 		if !ok {
@@ -329,7 +338,7 @@ func makeHorizontalPodAutoscalerChanges(kubeClient *k8s.Client, hpa *autoscaling
 		desiredState.LastUpdated = time.Now().Format(time.RFC3339)
 		hpaScalerStateByteArray, err := json.Marshal(desiredState)
 		if err != nil {
-			log.Error().Err(err)
+			log.Error().Err(err).Msg("")
 			return status, err
 		}
 		hpa.Metadata.Annotations[annotationHPAScalerState] = string(hpaScalerStateByteArray)
@@ -343,7 +352,7 @@ func makeHorizontalPodAutoscalerChanges(kubeClient *k8s.Client, hpa *autoscaling
 		// update hpa, because the data and state annotation have changed
 		hpa, err = kubeClient.AutoscalingV1().UpdateHorizontalPodAutoscaler(context.Background(), hpa)
 		if err != nil {
-			log.Error().Err(err)
+			log.Error().Err(err).Msg("")
 			return status, err
 		}
 
@@ -359,20 +368,8 @@ func makeHorizontalPodAutoscalerChanges(kubeClient *k8s.Client, hpa *autoscaling
 	return status, nil
 }
 
-func processHorizontalPodAutoscaler(kubeClient *k8s.Client, hpa *autoscalingv1.HorizontalPodAutoscaler, initiator string) (status string, err error) {
+func applyJitter(input int) (output int) {
+	deviation := int(0.25 * float64(input))
 
-	status = "failed"
-
-	if &hpa != nil && &hpa.Metadata != nil && &hpa.Metadata.Annotations != nil {
-
-		desiredState := getDesiredHorizontalPodAutoscalerState(hpa)
-
-		status, err = makeHorizontalPodAutoscalerChanges(kubeClient, hpa, initiator, desiredState)
-
-		return
-	}
-
-	status = "skipped"
-
-	return status, nil
+	return input - deviation + r.Intn(2*deviation)
 }

--- a/prometheus.go
+++ b/prometheus.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"errors"
 	"strconv"
 
 	"github.com/rs/zerolog/log"
@@ -31,7 +32,6 @@ type PrometheusQueryResponse struct {
 
 // UnmarshalPrometheusQueryResponse unmarshals the response for a prometheus query
 func UnmarshalPrometheusQueryResponse(responseBody []byte) (queryResponse PrometheusQueryResponse, err error) {
-
 	if err = json.Unmarshal(responseBody, &queryResponse); err != nil {
 		log.Error().Err(err).Msg("Failed unmarshalling prometheus query response")
 		return
@@ -44,6 +44,10 @@ func UnmarshalPrometheusQueryResponse(responseBody []byte) (queryResponse Promet
 
 // GetRequestRate converts the string value into a float64
 func (pqr *PrometheusQueryResponse) GetRequestRate() (float64, error) {
+	if pqr == nil || len(pqr.Data.Result) == 0 || len(pqr.Data.Result[0].Value) < 2 {
+		return 0, errors.New("The request metric is missing from the query result")
+	}
+
 	f, err := strconv.ParseFloat(pqr.Data.Result[0].Value[1].(string), 64)
 
 	return f, err

--- a/prometheus_test.go
+++ b/prometheus_test.go
@@ -7,7 +7,6 @@ import (
 )
 
 func TestUnmarshalPrometheusQueryResponse(t *testing.T) {
-
 	t.Run("ReturnsUnmarshalledResponse", func(t *testing.T) {
 
 		responseBody := []byte("{\"status\":\"success\",\"data\":{\"resultType\":\"vector\",\"result\":[{\"metric\":{\"location\":\"@searchfareapi_gcloud\"},\"value\":[1513161148.757,\"225.4068155675859\"]}]}}")
@@ -24,7 +23,6 @@ func TestUnmarshalPrometheusQueryResponse(t *testing.T) {
 }
 
 func TestGetRequestRate(t *testing.T) {
-
 	t.Run("ReturnsQueryValueAsFloat64", func(t *testing.T) {
 
 		queryResponse := PrometheusQueryResponse{
@@ -45,5 +43,37 @@ func TestGetRequestRate(t *testing.T) {
 
 		assert.Nil(t, err)
 		assert.Equal(t, 225.4068155675859, floatValue)
+	})
+
+	t.Run("ReturnsErrorIfResultIsMissing", func(t *testing.T) {
+
+		queryResponse := PrometheusQueryResponse{
+			Data: PrometheusQueryResponseData{
+				Result: []PrometheusQueryResponseDataResult{},
+			},
+		}
+
+		// act
+		_, err := queryResponse.GetRequestRate()
+
+		assert.NotNil(t, err)
+	})
+
+	t.Run("ReturnsErrorIfValueMissing", func(t *testing.T) {
+
+		queryResponse := PrometheusQueryResponse{
+			Data: PrometheusQueryResponseData{
+				Result: []PrometheusQueryResponseDataResult{
+					PrometheusQueryResponseDataResult{
+						Value: []interface{}{},
+					},
+				},
+			},
+		}
+
+		// act
+		_, err := queryResponse.GetRequestRate()
+
+		assert.NotNil(t, err)
 	})
 }


### PR DESCRIPTION
The pods running the autoscaler were occasionally restarted due to crashing, with these two errors:
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x10 pc=0x999b54]

goroutine 49 [running]:
main.main.func2(0xc4201d42a0, 0xc42021c000)
        /go/src/github.com/estafette/estafette-k8s-hpa-scaler/main.go:170 +0x4c4
```
This was caused by having a `if err != nil {` case, and doing some logging inside, but the rest of the code was not inside an `else`, so it was still executed in case of an error.

And the other was:

```
panic: runtime error: index out of range

goroutine 4 [running]:
main.(*PrometheusQueryResponse).GetRequestRate(0xc42033bb98, 0x3f, 0x600, 0xc4202029b0)
        /go/src/github.com/estafette/estafette-k8s-hpa-scaler/prometheus.go:47 +0xc2
```
I don't know the root cause, but either the `pqr.Data.Result` or the `pqr.Data.Result[0].Value` array didn't have enough items, so I added some precondition checks there.

There were a couple of places where we did a call like
```
		log.Fatal().Err(err)
```
The problem with this is that without calling `Msg()` on it (even with an empty string), nothing is logged, so I fixed these.

It was a bit weird that we had an empty line in the beginning of some functions, this doesn't seem to be a Golang convention, so I removed these.

And the last thing is that I reordered the functions in the `main.go` according to their abstraction level, I think this way it's easier to follow the code.