### PR TITLE
Scale down max percentage

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,18 @@ By tuning the `delta` and `requestsPerReplica` values it should be possible to f
 
 ### Limit the rate of scale down
 
-It can cause problems that the built in horizontal pod auto scaler can scale down a service too quickly if the CPU load drops. There is no built-in way to limit how big portion of the current pod count the auto scaler can remove in one step.  
+It can cause problems that the built in horizontal pod auto scaler can scale down a service too quickly if the CPU load drops. There is no built-in way to limit how big portion of the current pod count the auto scaler can remove in one step.
+
+The way the [Horizontal Pod Autoscaler](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/) works is that it periodically (by default, every 30 seconds) checks the target metric (for example the CPU-load) of the pods in our deployment, and if the pods are over or underutilized, it increases or decreases the replica count accordingly.  
+What this means in practice, is if we currently have 100 replicas, the current CPU-load is 10%, and the target CPU-load is 50%, then the auto scaler calculates the new replica count the following way:
+
+```
+newReplicaCount = 100 * (10 / 50)
+```
+
+So it scales the deployment down from 100 to 20 replicas.  
+Certain attributes (such as the frequency of checking the metrics, or the minimum wait time before subsequent scale downs) can be controlled globally on our cluster by passing in some flags to the controller manager. You can find more info about the possible options [here](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/).
+
 This can cause problems for services which are sensitive to being overloaded, and need time to scale back up, because a sudden drop in the CPU load can cause a degradation.
 
 To address this, you can set the `estafette.io/hpa-scaler-scale-down-max-ratio` annotation to control the maximum percentage of the pods that can be scaled down in one step.  

--- a/README.md
+++ b/README.md
@@ -36,7 +36,13 @@ cat kubernetes.yaml | \
     envsubst | kubectl apply -f -
 ```
 
-Once the controller is up and running you can annotate your `HorizontalPodAutoscaler` as follows to make the `minReplicas` follow the request rate retrieved by the Prometheus query:
+Once the controller is up and running you can annotate your `HorizontalPodAutoscaler` to control the value of `minReplicas`.  
+There are two ways we can use the scaler.
+
+### Use a Prometheus query
+
+The first option is to specify a Prometheus query which will control the minimum number of pods.  
+You have to use the following annotations to specify the Prometheus query (which should usually be a query that retrieves the incoming request rate of the first API in your stack):
 
 ```yaml
 apiVersion: autoscaling/v1
@@ -56,3 +62,23 @@ minReplicas = Ceiling ( delta + ( resultFromQuery / requestsPerReplica ) )
 ```
 
 By tuning the `delta` and `requestsPerReplica` values it should be possible to follow the curve of the number of requests coming out of the Prometheus query closely and stay just below the number of replicas that the `HorizontalPodAutoscaler` would come up with under normal circumstances. If the curve is higher you're wasting resources, if it's much lower than it provides less safety.
+
+### Limit the rate of scale down
+
+It can cause problems that the built in horizontal pod auto scaler can scale down a service too quickly if the CPU load drops. There is no built-in way to limit how big portion of the current pod count the auto scaler can remove in one step.  
+This can cause problems for services which are sensitive to being overloaded, and need time to scale back up, because a sudden drop in the CPU load can cause a degradation.
+
+To address this, you can set the `estafette.io/hpa-scaler-scale-down-max-ratio` annotation to control the maximum percentage of the pods that can be scaled down in one step.  
+For example this is the setup to limit the maximum scale down to 20%.
+
+```yaml
+apiVersion: autoscaling/v1
+kind: HorizontalPodAutoscaler
+metadata:
+  annotations:
+    estafette.io/hpa-scaler: "true"
+    estafette.io/hpa-scaler-scale-down-max-ratio: "0.2"
+```
+
+Both the Prometheus-query and the percentage based approach work by periodically updating the `minReplicas` property of the auto scaler.  
+We can use both at the same time, in that case the controller will choose the larger minimimum value.

--- a/main.go
+++ b/main.go
@@ -309,6 +309,7 @@ func makeHorizontalPodAutoscalerChanges(kubeClient *k8s.Client, hpa *autoscaling
 			Float64("desiredState.Delta + requestRate/desiredState.RequestsPerReplica", desiredState.Delta+requestRate/desiredState.RequestsPerReplica).
 			Float64("math.Ceil(desiredState.Delta + requestRate/desiredState.RequestsPerReplica)", math.Ceil(desiredState.Delta+requestRate/desiredState.RequestsPerReplica)).
 			Int32("int32(math.Ceil(desiredState.Delta + requestRate/desiredState.RequestsPerReplica))", int32(math.Ceil(desiredState.Delta+requestRate/desiredState.RequestsPerReplica))).
+			Int32("int32(math.Floor(float64(*hpa.Status.CurrentReplicas) * desiredState.ScaleDownMaxRatio))", int32(math.Floor(float64(*hpa.Status.CurrentReplicas)*desiredState.ScaleDownMaxRatio))).
 			Msgf("Calculated values for hpa %v in namespace %v", *hpa.Metadata.Name, *hpa.Metadata.Namespace)
 
 		// We pick the larger minimum of the two.

--- a/main.go
+++ b/main.go
@@ -264,13 +264,13 @@ func getDesiredHorizontalPodAutoscalerState(hpa *autoscalingv1.HorizontalPodAuto
 
 	scaleDownMaxRatioString, ok := hpa.Metadata.Annotations[annotationHPAScalerScaleDownMaxRatio]
 	if !ok {
-		state.ScaleDownMaxRatio = 0
+		state.ScaleDownMaxRatio = 1
 	} else {
 		i, err := strconv.ParseFloat(scaleDownMaxRatioString, 64)
 		if err == nil {
 			state.ScaleDownMaxRatio = i
 		} else {
-			state.ScaleDownMaxRatio = 0
+			state.ScaleDownMaxRatio = 1
 		}
 	}
 

--- a/main.go
+++ b/main.go
@@ -285,6 +285,11 @@ func makeHorizontalPodAutoscalerChanges(kubeClient *k8s.Client, hpa *autoscaling
 	status = "failed"
 
 	// check if hpa-scaler is enabled for this hpa and query is not empty and requests per replica larger than zero
+	if desiredState.Enabled == "true" {
+		minPodCountBasedOnPrometheusQuery = getMinPodCountBasedOnPrometheusQuery(kubeClient, hpa, initiator, desiredState)
+
+	}
+
 	if desiredState.Enabled == "true" && len(desiredState.PrometheusQuery) > 0 && desiredState.RequestsPerReplica > 0 {
 		minimumReplicasLowerBoundString := os.Getenv("MINIMUM_REPLICAS_LOWER_BOUND")
 		minimumReplicasLowerBound := int32(3)
@@ -386,6 +391,14 @@ func makeHorizontalPodAutoscalerChanges(kubeClient *k8s.Client, hpa *autoscaling
 	status = "skipped"
 
 	return status, nil
+}
+
+// Returns what the minimum pod count should be based on the Prometheus query specified
+func getMinPodCountBasedOnPrometheusQuery(kubeClient *k8s.Client, hpa *autoscalingv1.HorizontalPodAutoscaler, initiator string, desiredState HPAScalerState) (podCount int, err error) {
+}
+
+// Returns what the minimum pod count should be based on the current pod count and the 
+func getMinPodCountBasedOnCurrentPodCount(kubeClient *k8s.Client, hpa *autoscalingv1.HorizontalPodAutoscaler, initiator string, desiredState HPAScalerState) (podCount int, err error) {
 }
 
 func applyJitter(input int) (output int) {

--- a/main.go
+++ b/main.go
@@ -205,18 +205,16 @@ func main() {
 }
 
 func processHorizontalPodAutoscaler(kubeClient *k8s.Client, hpa *autoscalingv1.HorizontalPodAutoscaler, initiator string) (status string, err error) {
-	status = "failed"
-
 	if hpa != nil && hpa.Metadata != nil && hpa.Metadata.Annotations != nil {
 
 		desiredState := getDesiredHorizontalPodAutoscalerState(hpa)
 
-		status, err = makeHorizontalPodAutoscalerChanges(kubeClient, hpa, initiator, desiredState)
+		status, err := makeHorizontalPodAutoscalerChanges(kubeClient, hpa, initiator, desiredState)
+
+		return status, err
 	}
 
-	status = "skipped"
-
-	return status, nil
+	return "skipped", nil
 }
 
 func getDesiredHorizontalPodAutoscalerState(hpa *autoscalingv1.HorizontalPodAutoscaler) (state HPAScalerState) {
@@ -420,7 +418,7 @@ func getMinPodCountBasedOnPrometheusQuery(kubeClient *k8s.Client, hpa *autoscali
 func getMinPodCountBasedOnCurrentPodCount(kubeClient *k8s.Client, hpa *autoscalingv1.HorizontalPodAutoscaler, initiator string, desiredState HPAScalerState) (podCount int32) {
 	actualNumberOfReplicas := *hpa.Status.CurrentReplicas
 
-	// We use Floor() because we want to opt on the side of scaling  down slower
+	// We use Floor() because we want to opt on the side of scaling down slower.
 	maxScaleDown := int32(math.Floor(float64(actualNumberOfReplicas) * desiredState.ScaleDownMaxRatio))
 
 	// If the (number of replicas) * (scale down max ratio) is zero, that would completely prevent scaling down, which we don't want.


### PR DESCRIPTION
With a Kubernetes HPA, there is no way to control the maximum percentage of the replicas it can scale down in one go. So if the CPU-load drops down to a low value, the HPA can immediately scale down to a very low number of replicas.

This is concrete example where I stopped the load to an application, and the HPA scaled down from 18 to the minimum 3 pods in one go. (It looks gradual on this graph, but the scaling down happened in one go, just then the pods stopped at random times, but it happened under one minute):

![image](https://user-images.githubusercontent.com/1122274/46219161-e7453680-c346-11e8-9691-f954fcabf90e.png)

This can cause issues in applications which are sensitive to being overloaded, especially if the CPU-load is not linearly increasing with the traffic, because then this scale down can be too aggressive.  
This PR introduces a new annotation called `estafette.io/hpa-scaler-scale-down-max-ratio`, which is the maximum percentage of the current replica count with which the HPA is able to scale down in one go.  
The way we achieve this technically is that we adjust the `minPodCount` accordingly.

This new annotation can be used either together with a Prometheus query (in that case the larger minimum is chosen), or by itself.

By using this annotation and setting it to 10% (`0.1`) on the same service, after completely stopping the traffic, it was still only gradually scaled down:

![image](https://user-images.githubusercontent.com/1122274/46219317-56bb2600-c347-11e8-923b-9bc8519de684.png)