### PR TITLE
Log queryresponse as string instead of object

### DIFF
--- a/prometheus.go
+++ b/prometheus.go
@@ -37,7 +37,7 @@ func UnmarshalPrometheusQueryResponse(responseBody []byte) (queryResponse Promet
 		return
 	}
 
-	log.Debug().Interface("queryResponse", queryResponse).Msg("Successfully unmarshalled prometheus query response")
+	log.Debug().Str("queryResponse", string(responseBody)).Msg("Successfully unmarshalled prometheus query response")
 
 	return
 }


### PR DESCRIPTION
It causes trouble with our internal v3 log format; it should put any structured data nested in a `payload` field, however the zerolog library is not able to do this on a global level.